### PR TITLE
carrierwave.rbの:fogと’fog/aws’の後ろに ,  が抜けていたため追加

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -9,8 +9,8 @@ CarrierWave.configure do |config|
     config.storage = :file
   elsif Rails.env.production?
     config.fog_credentials = {
-      config.storage = :fog
-      config.fog_provider = 'fog/aws'
+      config.storage = :fog,
+      config.fog_provider = 'fog/aws',
       provider: 'AWS',
       aws_access_key_id: Rails.application.secrets.aws_access_key_id,
       aws_secret_access_key: Rails.application.secrets.aws_secret_access_key,


### PR DESCRIPTION
## WHAT
:fogと’fog/aws’の後ろに ,  が抜けていたため追加
## WHAY
deployでエラーが出たため修正