### PR TITLE
carrierwave.rbのconfig.fog_credentialsの記述を変更

### DIFF
--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -8,9 +8,9 @@ CarrierWave.configure do |config|
   if Rails.env.development? || Rails.env.test?
     config.storage = :file
   elsif Rails.env.production?
-    config.fog_credentials = {
       config.storage = :fog,
       config.fog_provider = 'fog/aws',
+      config.fog_credentials = {
       provider: 'AWS',
       aws_access_key_id: Rails.application.secrets.aws_access_key_id,
       aws_secret_access_key: Rails.application.secrets.aws_secret_access_key,


### PR DESCRIPTION
## WHAT
carrierwave.rbのconfig.fog_credentialsの記述を変更

## WHAY
config.fog_credentials = { 内にconfig.storage = :fog,config.fog_provider
= 'fog/aws’を記述するとエラーになるため外にconfig.fog_credentialsの外に記述